### PR TITLE
Add stats introduction

### DIFF
--- a/data/en/ui.json
+++ b/data/en/ui.json
@@ -48,6 +48,9 @@
     "statsConfirmText": "Confirm Changes",
     "statsReturnToGameText": "Return to game",
     "statsHeaderText": "Stats",
+    "statsIntroductionText": "Since this is the first time you're entering the stats screen, here is a short introduction. <br/> <br/> This is where you can spend your available points by pressing on any one of the stats from the Stat screen. Upon each press, you will spend one available point in order to gain one level in that stat.<br/> <br/> Your number of available points is shown at the top of the Stat screen.<br/> <br/> You can cancel or confirm your changes by using the buttons at the bottom of the screen.<br/> <br/> Every once in a while, the game will check to see if your stats are high enough to perform a certain action in a scene. If your stat level is not high enough you will fail your check, which will be announced by a red message on top of your screen. A succesful stat check will be shown in green. Here are two examples:<br/> <br/>",
+    "statsIntroductionButton": "Continue to stats screen",
+        
     
     "settingsLanguageText": "Change language",
     "settingsNightModeActivateText": "Activate night mode",

--- a/data/fr/ui.json
+++ b/data/fr/ui.json
@@ -49,6 +49,8 @@
     "statsConfirmText": "Confirmer les changements",
     "statsReturnToGameText": "Retour au jeu",
     "statsHeaderText": "Stats",
+    "statsIntroductionText": "Puisqu'il s'agit de la première fois que vous visitez cet écran, voilà une courte introduction. <br/> <br/>Vous pouvez dépenser vos points disponibles en cliquant sur une des stats de l'écran Stats. Après chaque clic, un point sera dépensé pour augmenter le niveau de la stat de 1.<br/><br/>Votre nombre de points disponibles est visible en haut de l'écran Stats.<br/><br/>Vous pouvez annuler ou confirmer les changements en utilisant les boutons en bas de l'écran.<br/><br/>De temps en temps, le jeu vérifie si vos stats sont suffisamment élevées pour effectuer certaines actions. Si votre niveau n'est pas suffisant, vous échouerez, ce qui sera annoncé par un message rouge en haut de l'écran. Un succès sera indiqué par un message vert. Voici deux examples : <br/><br/>",
+    "statsIntroductionButton": "Continuer vers l'écran des stats",
 
     "settingsLanguageText": "Changer de langue",
     "settingsNightModeActivateText": "Activer le mode sombre",

--- a/public/styles/stats.css
+++ b/public/styles/stats.css
@@ -117,3 +117,31 @@
 .updated {
     color: var(--stat-update-text-color);
 }
+.first-time-stats-modal {
+    position: fixed;
+    z-index: 1;
+    left: 50%;
+    top: 35%;
+    transform: translate(-50%, -50%);
+    width: 300px;
+    height: 450px;
+    background-color: var(--background-color);
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    padding: 1em;
+    border: solid 3px #535353;
+}
+
+.first-time-stats-continue {
+    padding: 1em;
+    width: 30%;
+    background-color: #535353;
+    color: white;
+}
+
+@media (min-width: 800px) {
+    .first-time-stats-modal {
+        width: 600px;
+        height: 450px;
+    }
+}

--- a/templates/stats.ejs
+++ b/templates/stats.ejs
@@ -196,6 +196,33 @@
     </div>
 </div>
 <% }; %>
+<% if ( !locals.v_stats_seen ) { %>
+    <div id="firstTimeStatsModal" class="first-time-stats-modal" _="on closeModal remove me">
+        Since this is the first time you're entering the stats screen, here is a short introduction. <br/>
+        <br/>
+        This is where you can spend your available points by pressing on any one of the stats from the Stat screen. Upon each press, you will spend one available point in order to gain one level in that stat.<br/>
+        <br/>
+        Your number of available points is shown at the top of the Stat screen.<br/>
+        <br/>
+        You can cancel or confirm your changes by using the buttons at the bottom of the screen.<br/>
+        <br/>
+        Every once in a while, the game will check to see if your stats are high enough to perform a certain action in a scene. If your stat level is not high enough you will fail your check, which will be announced by a red message on top of your screen. A succesful stat check will be shown in green. Here are two examples:<br/>
+        <br/>
+        <div class='stat_fail'>
+            [ Ancient languages check failed - level 3 ]
+        </div>
+        <br/>
+        <div class='stat_success'>
+            [ Combat technique check succesful - level 2 ]
+        </div>
+        <br/>
+        <div style="display:flex;align-items:center;flex-direction:column;">
+            <button class="first-time-stats-continue" _="on click cookieAdd('v_stats_seen',1) then trigger closeModal">
+                Continue to stats screen
+            </div>
+        </div>
+    </div>
+<% } %>
 <div style="display:none">
     <h2 id="header" hx-swap-oob="true">
         <%= statsHeaderText %>

--- a/templates/stats.ejs
+++ b/templates/stats.ejs
@@ -186,7 +186,7 @@
                 <img src="/images/achievement_trophy.png" width="100" height="100" />
                 <div class="achievement-modal-content">
                     <div class="achievement-modal-title">
-                        ACHIEVEMENT UNLOCKED 
+                        <%= mainAchievementUnlockedText %>
                     </div>
                     <div class="achievement-modal-caption">
                       Full immersion
@@ -198,16 +198,7 @@
 <% }; %>
 <% if ( !locals.v_stats_seen ) { %>
     <div id="firstTimeStatsModal" class="first-time-stats-modal" _="on closeModal remove me">
-        Since this is the first time you're entering the stats screen, here is a short introduction. <br/>
-        <br/>
-        This is where you can spend your available points by pressing on any one of the stats from the Stat screen. Upon each press, you will spend one available point in order to gain one level in that stat.<br/>
-        <br/>
-        Your number of available points is shown at the top of the Stat screen.<br/>
-        <br/>
-        You can cancel or confirm your changes by using the buttons at the bottom of the screen.<br/>
-        <br/>
-        Every once in a while, the game will check to see if your stats are high enough to perform a certain action in a scene. If your stat level is not high enough you will fail your check, which will be announced by a red message on top of your screen. A succesful stat check will be shown in green. Here are two examples:<br/>
-        <br/>
+        <%- statsIntroductionText %>
         <div class='stat_fail'>
             [ Ancient languages check failed - level 3 ]
         </div>
@@ -218,7 +209,7 @@
         <br/>
         <div style="display:flex;align-items:center;flex-direction:column;">
             <button class="first-time-stats-continue" _="on click cookieAdd('v_stats_seen',1) then trigger closeModal">
-                Continue to stats screen
+                <%= statsIntroductionButton %>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Adds a modal that shows up the first time you open the stats panel explaining how it works. Closes #49.