### PR TITLE
Use localStorage instead of cookies for storing game data

### DIFF
--- a/public/scripts/stats.js
+++ b/public/scripts/stats.js
@@ -3,15 +3,10 @@
 // Check if some of the stats are undefined.
 // If they are, update every stat cookie with the default value 0, and reload the page.
 
-function getDefaultStatsVariables() {
-    const stats_variables = ["v_available_points", "v_strength", "v_toughness", "v_agility", "v_reflexes",
-        "v_hearing", "v_perception", "v_ancient_languages", "v_combat_technique", "v_premonition",
-        "v_bluff", "v_magical_sense", "v_aura_hardening", "v_magical_power", "v_magical_knowledge",
-        "v_max_stat"]
-    return stats_variables;
-}
-
-const stats_variables = getDefaultStatsVariables();
+const stats_variables = ["v_available_points", "v_strength", "v_toughness", "v_agility", "v_reflexes",
+    "v_hearing", "v_perception", "v_ancient_languages", "v_combat_technique", "v_premonition",
+    "v_bluff", "v_magical_sense", "v_aura_hardening", "v_magical_power", "v_magical_knowledge",
+    "v_max_stat"]
 
 
 

--- a/public/scripts/stats.js
+++ b/public/scripts/stats.js
@@ -13,7 +13,6 @@ function getDefaultStatsVariables() {
 
 const stats_variables = getDefaultStatsVariables();
 
-let locals = getCookies(); // From the utils.js file
 
 
 function initStats(event) {
@@ -22,27 +21,22 @@ function initStats(event) {
     if (page != "stats") {
         return;
     }
-    locals = getCookies()
+    locals = readSaveFromLocalStorage("currentState");
 
     var reload = false;
     stats_variables.forEach(function(stat) {
         const value = locals[stat];
-        console.log(stat);
-        console.log(value);
         if (value === null || value === undefined) {
             if (stat === 'v_max_stat') {
-                storeItem(stat, "3") // From the utils.js file
+                locals[stat] = 3;
             } else {
-                storeItem(stat, "0")
-            }
-            // Temporary points
-            if (stat === 'v_available_points') {
-                storeItem(stat, "0")
+                locals[stat] = 0;
             }
             reload = true;
         }
     });
     if (reload) {
+        writeSaveToLocalStorage("currentState",locals);
         window.location.reload();
     }
 }
@@ -78,6 +72,7 @@ function getAuxiliaryStatMapping() {
 }
 
 function initializeAuxiliaryProperty(stat_property, default_value) {
+    let locals = readSaveFromLocalStorage("currentState");
     const stat_value = locals[stat_property] && !Number.isNaN(locals[stat_property]) ? 
         parseInt(locals[stat_property]) : 0;
     return stat_value;
@@ -129,6 +124,7 @@ let stats_changed = false; // This variable is used to check if the stats have b
 
 function updateStat(stat, stat_aux_key, stat_field_id, stat_field_value_id) {
     let stat_aux_value = stats_aux[stat_aux_key];
+    let locals = readSaveFromLocalStorage("currentState");
     const stat_max = locals["v_max_stat"];
     const available_points = stats_aux["v_available_points_aux"];
 
@@ -145,11 +141,13 @@ function confirmStats() {
     if (!stats_changed) { return; }
     // Update the stats cookies
     const stats_aux_mapping = getAuxiliaryStatMapping();
+    let locals = readSaveFromLocalStorage("currentState");
     for (let stat_aux in stats_aux) {
         let stat_aux_mapping = stats_aux_mapping[stat_aux]
         let stat = stat_aux_mapping["stat"]
-        storeItem(stat, stats_aux[stat_aux])
+        locals[stat] = stats_aux[stat_aux]
     }
+    writeSaveToLocalStorage("currentState",locals);
     // Refresh the page to reflect the changes
     window.location.reload();
 }

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -7,36 +7,19 @@ function getCookie(name) {
     return null;
 }
 
-const getCookies = function () {
-    const pairs = document.cookie.split(";");
-    const cookies = {};
-    for (let i = 0; i < pairs.length; i++) {
-        const pair = pairs[i].split("=");
-        cookies[(pair[0] + '').trim()] = unescape(pair.slice(1).join('='));
-    }
-    return cookies;
-};
-
-function cookieSet(key,value) {
-    document.cookie = key+"="+value+";path=/";
-}
-
-function cookieAdd(name,value) {
-    const current_value = getCookie(name) || 0
-    cookieSet(name,parseInt(current_value)+parseInt(value))
-}
-
 function storeItem(key,value) {
-      value = value.toString();
-      if (value.startsWith("+")){
-          cookieAdd(key,value.slice(1))
-      }
-      else if (value.startsWith("-")){
-          cookieAdd(key,-parseInt(value.slice(1)))
-      }
-      else {
-          cookieSet(key,value)
-      }
+    let data = readSaveFromLocalStorage("currentState")
+    value = value.toString();
+    if (value.startsWith("+")){
+        data[key] = (data[key] || 0) + parseInt(value.slice(1))
+    }
+    else if (value.startsWith("-")){
+        data[key] = (data[key] || 0) - parseInt(value.slice(1))
+    }
+    else {
+        data[key] = value;
+    }
+    writeSaveToLocalStorage("currentState",data)
 }
 
 function setTheme(theme) {
@@ -58,22 +41,11 @@ function scrollToTop() {
   window.scroll(0, 0);
 }
 
-function setResponseCookies(response) {
+function setResponseVariables(response) {
   scrollToTop();
 
   for (const [key, value] of Object.entries(response.setVariables)) {
       storeItem(key,value)
   }
 }
-
-function clearState() {
-    document.cookie.split(';').forEach(cookie => {
-        const eqPos = cookie.indexOf('=');
-        const name = eqPos > -1 ? cookie.substring(0, eqPos) : cookie;
-        if (/v_.*/.test(name) && !(/.*_ac_.*/.test(name))) {
-            document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
-        }
-    });
-}
-
 

--- a/templates/language.ejs
+++ b/templates/language.ejs
@@ -2,7 +2,7 @@
     <% for (entry of Object.entries(locales)) { %>
         <div class="response">
             <button
-                onClick="storeItem('locale','<%= entry[0] %>');window.location.reload()"
+                onClick="document.cookie='locale=<%= entry[0] %>';window.location.reload()"
             > 
                 <%= entry[1] %>
             </button>

--- a/templates/main.ejs
+++ b/templates/main.ejs
@@ -31,20 +31,25 @@
 <% for (choice of scene.choices) {%>
     <div class="response">
         <button
-        onClick="setResponseCookies(<%= JSON.stringify(choice) %>)"
+        onClick="setResponseVariables(<%= JSON.stringify(choice) %>)"
         <% if (!choice.special) { %>
-            hx-get="/"
+            hx-post="/"
+            hx-ext="submitcurrentstate"
         <% } else if (choice.special=="stats") { %>
-            hx-get="/stats"
+            hx-post="/stats"
+            hx-ext="submitcurrentstate"
             hx-push-url="true"
         <% } else if (choice.special === "checkpoint_load") { %>
-            hx-get="/"
+            hx-post="/"
+            hx-ext="submitcurrentstate"
             hx-on::before-request="loadGameFromLocalStorage('checkpoint')"
         <% } else if (choice.special=="checkpoint_save") { %>
-            hx-get="/"
+            hx-post="/"
+            hx-ext="submitcurrentstate"
             hx-on::before-request="saveGameToLocalStorage('checkpoint')"
         <% } else if (choice.special=="restart") { %>
-            hx-get="/"
+            hx-post="/"
+            hx-ext="submitcurrentstate"
             hx-on::before-request="clearState()"
         <% } else if (choice.special === "saves") { %>
             hx-post="/saves/0"

--- a/templates/menu.ejs
+++ b/templates/menu.ejs
@@ -1,7 +1,8 @@
 <div class="main-menu">
     <div class="response">
         <button
-            hx-get="/"
+            hx-post="/"
+            hx-ext="submitcurrentstate"
             hx-target="#content"
             hx-swap="innerHTML"
             hx-push-url="true"
@@ -11,7 +12,8 @@
     </div>
     <div class="response">
         <button
-            hx-get="/"
+            hx-post="/"
+            hx-ext="submitcurrentstate"
             hx-on::before-request="clearState()"
             hx-target="#content"
             hx-swap="innerHTML"
@@ -22,7 +24,8 @@
     </div>
     <div class="response">
         <button
-            hx-get="/"
+            hx-post="/"
+            hx-ext="submitcurrentstate"
             hx-on::before-request="loadGameFromLocalStorage('checkpoint')"
             hx-target="#content"
             hx-swap="innerHTML"

--- a/templates/outline.ejs
+++ b/templates/outline.ejs
@@ -37,10 +37,12 @@
         <div class="header">
             <button class="header-left" hx-get="/menu" hx-target="#content" hx-swap="innerHTML" hx-push-url="true"><%= outlineMenuButtonText %></button>
           <h2 id="header"><%= header %></h2>
-          <button class="header-right" hx-get="/stats" hx-target="#content" hx-swap="innerHTML" hx-push-url="true"><%= outlineStatsButtonText %></button>
+          <button class="header-right" hx-post="/stats" hx-ext="submitcurrentstate" hx-target="#content" hx-swap="innerHTML" hx-push-url="true"><%= outlineStatsButtonText %></button>
         </div>
         <% if ((locals.path.includes("/saves")) || (locals.path.includes("/local_saves"))) { %>
             <div id="content" class="content" hx-post hx-trigger="load" hx-ext="submitlocalstorage"></div>
+        <% } else if (locals.path === "/" || locals.path === "/stats") { %>
+            <div id="content" class="content" hx-post hx-trigger="load" hx-ext="submitcurrentstate"></div>
         <% } else { %>
             <div id="content" class="content" hx-get hx-trigger="load"></div>
         <% } %>

--- a/templates/saves.ejs
+++ b/templates/saves.ejs
@@ -21,7 +21,8 @@
             <% if (saveData[`save${i}`]) { %>
                 <button 
                     style="flex-grow: 1;"
-                    hx-get="/"
+                    hx-post="/"
+                    hx-ext="submitcurrentstate"
                     hx-on::before-request="loadGameFromLocalStorage('save<%= i %>')"
                     hx-target="#content"
                     hx-swap="innerHTML"
@@ -121,7 +122,8 @@ Same hard-coding is done in the backend-->
 </div>
 <div class="response">
     <button
-        hx-get="/"
+        hx-post="/"
+        hx-ext="submitcurrentstate"
         hx-target="#content"
         hx-swap="innerHTML"
         hx-push-url="true"

--- a/templates/settings.ejs
+++ b/templates/settings.ejs
@@ -33,7 +33,7 @@
         <div>
             <%- settingsCheatModeModalText %>
         </div>
-            <button class="cheatmode-modal-yes" _="on click cookieAdd('v_available_points',50) then cookieAdd('v_available_points_aux',50) then trigger closeModal"><%= localeYes %></button>
+            <button class="cheatmode-modal-yes" _="on click storeItem('v_available_points',50) then storeItem('v_available_points_aux',50) then trigger closeModal"><%= localeYes %></button>
         <br>
             <button class="cheatmode-modal-no" _="on click trigger closeModal"><%= localeNo %></button>
     </div>

--- a/templates/stats.ejs
+++ b/templates/stats.ejs
@@ -171,7 +171,7 @@
     id="cancel-changes"><%= statsCancelText %></button>
 <button onclick="confirmStats()" 
     id="confirm-changes"><%= statsConfirmText %></button>
-<button hx-get="/" hx-target="#content" hx-swap="innerHTML" hx-push-url="/"
+<button hx-post="/" hx-ext="submitcurrentstate" hx-target="#content" hx-swap="innerHTML" hx-push-url="/"
     id="return-to-game"><%= statsReturnToGameText %></button>
 </div>
 <% if (maximized && ((locals.v_ac_ch6_immersion || 0) === 0)) { %>
@@ -196,7 +196,7 @@
     </div>
 </div>
 <% }; %>
-<% if ( !locals.v_stats_seen ) { %>
+<% if ( !locals.stats_intro_seen ) { %>
     <div id="firstTimeStatsModal" class="first-time-stats-modal" _="on closeModal remove me">
         <%- statsIntroductionText %>
         <div class='stat_fail'>
@@ -208,7 +208,7 @@
         </div>
         <br/>
         <div style="display:flex;align-items:center;flex-direction:column;">
-            <button class="first-time-stats-continue" _="on click cookieAdd('v_stats_seen',1) then trigger closeModal">
+            <button class="first-time-stats-continue" _="on click js document.cookie='stats_intro_seen=1' end then trigger closeModal">
                 <%= statsIntroductionButton %>
             </div>
         </div>


### PR DESCRIPTION
It turns out there is a limit of 180 cookies maximum for a given website, which we reach during book 3, causing some cookies to get dropped (see #102). This moves the game state to the localStorage.  Although the htmx logic is a tiny bit more complicated, this simplifies a lot the saving and loading of saves (basically simply replacing the "currentState" slot with the save slot and vice-versa. Cookies are now only used for normal stuff like night mode or locale (also decoupling them from saves which is nice).