### PR TITLE
Simplify stats page handling

### DIFF
--- a/public/scripts/stats.js
+++ b/public/scripts/stats.js
@@ -3,11 +3,10 @@
 // Check if some of the stats are undefined.
 // If they are, update every stat cookie with the default value 0, and reload the page.
 
-const stats_variables = ["v_available_points", "v_strength", "v_toughness", "v_agility", "v_reflexes",
-    "v_hearing", "v_perception", "v_ancient_languages", "v_combat_technique", "v_premonition",
-    "v_bluff", "v_magical_sense", "v_aura_hardening", "v_magical_power", "v_magical_knowledge",
-    "v_max_stat"]
-
+const stats_names = ["available_points", "strength", "toughness", "agility", "reflexes",
+    "hearing", "perception", "ancient_languages", "combat_technique", "premonition",
+    "bluff", "magical_sense", "aura_hardening", "magical_power", "magical_knowledge",
+    "max_stat"]
 
 
 function initStats(event) {
@@ -19,13 +18,14 @@ function initStats(event) {
     locals = readSaveFromLocalStorage("currentState");
 
     var reload = false;
-    stats_variables.forEach(function(stat) {
-        const value = locals[stat];
+    stats_names.forEach(function(stat) {
+        const stat_var = "v_" + stat;
+        const value = locals[stat_var];
         if (value === null || value === undefined) {
-            if (stat === 'v_max_stat') {
-                locals[stat] = 3;
+            if (stat_var === 'v_max_stat') {
+                locals[stat_var] = 3;
             } else {
-                locals[stat] = 0;
+                locals[stat_var] = 0;
             }
             reload = true;
         }
@@ -38,111 +38,26 @@ function initStats(event) {
 document.addEventListener("htmx:afterSwap", initStats)
 document.addEventListener("DOMContentLoaded", initStats)
 
-// Logic for updating stats
+function updateStat(stat_id) {
+    const available_points = parseInt(document.getElementById("available_points_value").innerHTML);
+    const current_val = parseInt(document.getElementById(stat_id + "_value").innerHTML);
+    const max_val = parseInt(document.getElementById(stat_id + "_max").innerHTML);;
 
-// Mapping dictionary to establish the relation between the auxiliary stat 
-//  and its corresponding stat, field_name, and span id.
-// Note: Attempt is to improve upon the previous problematic approach 
-//  where we had hard-coding of the relations in some places (e.g. getAuxiliaryStats)
-//  and infer relations in others, (e.g. initializeStats)
-function getAuxiliaryStatMapping() {
-    let stats_aux_mapping = {};
-    stats_aux_mapping["v_available_points_aux"] = {"stat": "v_available_points", "field_id": "available_points", "value_span_id": "available_points_value"};
-    stats_aux_mapping["v_strength_aux"] = {"stat": "v_strength", "field_id": "strength", "value_span_id": "strength_value"};
-    stats_aux_mapping["v_toughness_aux"] = {"stat": "v_toughness", "field_id": "toughness", "value_span_id": "toughness_value"};
-    stats_aux_mapping["v_agility_aux"] = {"stat": "v_agility", "field_id": "agility", "value_span_id": "agility_value"};
-    stats_aux_mapping["v_reflexes_aux"] = {"stat": "v_reflexes", "field_id": "reflexes", "value_span_id": "reflexes_value"};
-    stats_aux_mapping["v_hearing_aux"] = {"stat": "v_hearing", "field_id": "hearing", "value_span_id": "hearing_value"};
-    stats_aux_mapping["v_perception_aux"] = {"stat": "v_perception", "field_id": "perception", "value_span_id": "perception_value"};
-    stats_aux_mapping["v_ancient_languages_aux"] = {"stat": "v_ancient_languages", "field_id": "ancient_languages", "value_span_id": "ancient_languages_value"};
-    stats_aux_mapping["v_combat_technique_aux"] = {"stat": "v_combat_technique", "field_id": "combat_technique", "value_span_id": "combat_technique_value"};
-    stats_aux_mapping["v_premonition_aux"] = {"stat": "v_premonition", "field_id": "premonition", "value_span_id": "premonition_value"};
-    stats_aux_mapping["v_bluff_aux"] = {"stat": "v_bluff", "field_id": "bluff", "value_span_id": "bluff_value"};
-    stats_aux_mapping["v_magical_sense_aux"] = {"stat": "v_magical_sense", "field_id": "magical_sense", "value_span_id": "magical_sense_value"};
-    stats_aux_mapping["v_aura_hardening_aux"] = {"stat": "v_aura_hardening", "field_id": "aura_hardening", "value_span_id": "aura_hardening_value"};
-    stats_aux_mapping["v_magical_power_aux"] = {"stat": "v_magical_power", "field_id": "magical_power", "value_span_id": "magical_power_value"};
-    stats_aux_mapping["v_magical_knowledge_aux"] = {"stat": "v_magical_knowledge", "field_id": "magical_knowledge", "value_span_id": "magical_knowledge_value"};
-
-    return stats_aux_mapping;
-}
-
-function initializeAuxiliaryProperty(stat_property, default_value) {
-    let locals = readSaveFromLocalStorage("currentState");
-    const stat_value = locals[stat_property] && !Number.isNaN(locals[stat_property]) ? 
-        parseInt(locals[stat_property]) : 0;
-    return stat_value;
-}
-
-// Define temporary global variables for the stats
-// Can also later set up two-way binding directly with the HTML elements using Object.defineProperty
-function getAuxiliaryStats(stats_aux_mapping = null) {
-    if (!stats_aux_mapping) {
-        stats_aux_mapping = getAuxiliaryStatMapping();
-    }
-
-    let stats_aux = {}
-    for (const [stat_aux, stat_aux_mapping] of Object.entries(stats_aux_mapping)) {
-        let stat = stat_aux_mapping["stat"];
-        stats_aux[stat_aux] = initializeAuxiliaryProperty(stat, 0);
-    }
-
-    return stats_aux;
-}
-
-// This function is called on page load to initialize the stats
-// As well as to update when Cancel Changes is clicked
-function initializeStats(stats_aux, stats_aux_mapping = null, reset_magic_stats = true) {
-    if (!stats_aux_mapping) {
-        stats_aux_mapping = getAuxiliaryStatMapping();
-    }
-
-    for (const [stat_aux, stat_aux_value] of Object.entries(stats_aux)) {
-        if (!reset_magic_stats && 
-        (stat_aux === "v_magical_power_aux" || stat_aux === "v_magical_knowledge_aux")) {
-            continue;
-        }
-        let stat_aux_mapping = stats_aux_mapping[stat_aux]
-        let stat = stat_aux_mapping["stat"];
-        let stat_field_id = stat_aux_mapping["field_id"];
-        let stat_value_span_id = stat_aux_mapping["value_span_id"]
-        if (document.getElementById(stat_value_span_id) === null) {continue;}
-        document.getElementById(stat_value_span_id).innerHTML = stat_aux_value;
-        document.getElementById(stat_field_id).className = "stat-field" + 
-            (stat === "v_available_points" ? " available" : "") +
-            (stat === "v_magical_power" || stat === "v_magical_knowledge" ? " magic-special" : "");
-    }
-}
-
-let stats_aux = getAuxiliaryStats();
-initializeStats(stats_aux);
-let stats_changed = false; // This variable is used to check if the stats have been changed
-
-function updateStat(stat, stat_aux_key, stat_field_id, stat_field_value_id) {
-    let stat_aux_value = stats_aux[stat_aux_key];
-    let locals = readSaveFromLocalStorage("currentState");
-    const stat_max = locals["v_max_stat"];
-    const available_points = stats_aux["v_available_points_aux"];
-
-    if ((stat_aux_value >= stat_max) || (available_points <= 0)) { return; }
-    stats_aux[stat_aux_key] += 1;
-    stats_aux["v_available_points_aux"] -= 1;
-    document.getElementById("available_points_value").innerHTML = stats_aux["v_available_points_aux"];
-    document.getElementById(stat_field_value_id).innerHTML = stats_aux[stat_aux_key];
-    document.getElementById(stat_field_id).className = "stat-field updated";
-    stats_changed = true;
+    if ((current_val >= max_val) || (available_points <= 0)) { return; }
+    document.getElementById("available_points_value").innerHTML = available_points - 1;
+    document.getElementById(stat_id + "_value").innerHTML = current_val + 1;
+    document.getElementById(stat_id).className = "stat-field updated";
 }
 
 function confirmStats() {
-    if (!stats_changed) { return; }
-    // Update the stats cookies
-    const stats_aux_mapping = getAuxiliaryStatMapping();
-    let locals = readSaveFromLocalStorage("currentState");
-    for (let stat_aux in stats_aux) {
-        let stat_aux_mapping = stats_aux_mapping[stat_aux]
-        let stat = stat_aux_mapping["stat"]
-        locals[stat] = stats_aux[stat_aux]
+    let data = readSaveFromLocalStorage("currentState");
+    for (const stat_name of stats_names) {
+        const element = document.getElementById(stat_name + "_value");
+        if (element) {
+            data["v_" + stat_name] = parseInt(element.innerHTML);;
+        }
     }
-    writeSaveToLocalStorage("currentState",locals);
+    writeSaveToLocalStorage("currentState",data);
     // Refresh the page to reflect the changes
     window.location.reload();
 }

--- a/templates/stats.ejs
+++ b/templates/stats.ejs
@@ -28,102 +28,102 @@
     </button>
 
     <button class="stat-field" id="strength" 
-    onclick="updateStat('strength', 'v_strength_aux', 'strength', 'strength_value')" 
+    onclick="updateStat(this.id)" 
     style="grid-column: 1; grid-row: 3;">
         <%= statsStrengthText %>:
         <span id="strength_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_strength) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
         <%= (locals.v_strength) || 0 %>
         </span>
         /
-        <%= (locals.v_max_stat) || 3 %>
+        <span id="strength_max"><%= (locals.v_max_stat) || 3 %></span>
     </button>
 
     <button class="stat-field" id="toughness" 
-    onclick="updateStat('toughness', 'v_toughness_aux', 'toughness', 'toughness_value')"
+    onclick="updateStat(this.id)"
     style="grid-column: 1; grid-row: 4;">
         <%= statsToughnessText %>:
         <span id="toughness_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_toughness) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
         <%= (locals.v_toughness) || 0 %>
         </span>
         /
-        <%= (locals.v_max_stat) || 3 %>
+        <span id="toughness_max"><%= (locals.v_max_stat) || 3 %></span>
     </button>
 
     <button class="stat-field" id="agility"
-    onclick="updateStat('agility', 'v_agility_aux', 'agility', 'agility_value')"
+    onclick="updateStat(this.id)"
     style="grid-column: 2; grid-row: 3;">
         <%= statsSpeedText %>:
         <span id="agility_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_agility) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
         <%= (locals.v_agility) || 0 %>
         </span>
         /
-        <%= (locals.v_max_stat) || 3 %>
+        <span id="agility_max"><%= (locals.v_max_stat) || 3 %></span>
     </button>
 
     <button class="stat-field" id="reflexes"
-    onclick="updateStat('reflexes', 'v_reflexes_aux', 'reflexes', 'reflexes_value')"
+    onclick="updateStat(this.id)"
     style="grid-column: 2; grid-row: 4;">
         <%= statsReflexesText %>:
         <span id="reflexes_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_reflexes) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
         <%= (locals.v_reflexes) || 0 %>
         </span>
         /
-        <%= (locals.v_max_stat) || 3 %>
+        <span id="reflexes_max"><%= (locals.v_max_stat) || 3 %></span>
     </button>
 
     <button class="stat-field" id="hearing"
-    onclick="updateStat('hearing', 'v_hearing_aux', 'hearing', 'hearing_value')"
+    onclick="updateStat(this.id)"
     style="grid-column: 1; grid-row: 5;">
         <%= statsHearingText %>:
         <span id="hearing_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_hearing) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
         <%= (locals.v_hearing) || 0 %>
         </span>
         /
-        <%= (locals.v_max_stat) || 3 %>
+        <span id="hearing_max"><%= (locals.v_max_stat) || 3 %></span>
     </button>
 
     <button class="stat-field" id="perception" 
-    onclick="updateStat('perception', 'v_perception_aux', 'perception', 'perception_value')"
+    onclick="updateStat(this.id)"
     style="grid-column: 2; grid-row: 5;">
-        <%= statsPerceptionText %>:
+        <%= statsObservationText %>:
         <span id="perception_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_perception) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
         <%= (locals.v_perception) || 0 %>
         </span>
         /
-        <%= (locals.v_max_stat) || 3 %>
+        <span id="perception_max"><%= (locals.v_max_stat) || 3 %></span>
     </button>
 
     <button class="stat-field" id="ancient_languages"
-    onclick="updateStat('ancient_languages', 'v_ancient_languages_aux', 'ancient_languages', 'ancient_languages_value')"
+    onclick="updateStat(this.id)"
     style="grid-column: 1 / span 2; grid-row: 6;">
         <%= statsAncientLanguagesText %>:
         <span id="ancient_languages_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_ancient_languages) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
         <%= (locals.v_ancient_languages) || 0 %>
         </span>
         /
-        <%= (locals.v_max_stat) || 3 %>
+        <span id="ancient_languages_max"><%= (locals.v_max_stat) || 3 %></span>
     </button>
 
     <button class="stat-field" id="combat_technique"
-    onclick="updateStat('combat_technique', 'v_combat_technique_aux', 'combat_technique', 'combat_technique_value')"
+    onclick="updateStat(this.id)"
     style="grid-column: 1 / span 2; grid-row: 7;">
         <%= statsCombatTechniqueText %>:
         <span id="combat_technique_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_combat_technique) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
         <%= (locals.v_combat_technique) || 0 %>
         </span>
         /
-        <%= (locals.v_max_stat) || 3 %>
+        <span id="combat_technique_max"><%= (locals.v_max_stat) || 3 %></span>
     </button>
 
     <button class="stat-field" id="premonition" 
-    onclick="updateStat('premonition', 'v_premonition_aux', 'premonition', 'premonition_value')"
+    onclick="updateStat(this.id)"
     style="grid-column: 1 / span 2; grid-row: 8;">
         <%= statsPremonitionText %>:
         <span id="premonition_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_premonition) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
         <%= (locals.v_premonition) || 0 %>
         </span>
         /
-        <%= (locals.v_max_stat) || 3 %>
+        <span id="premonition_max"><%= (locals.v_max_stat) || 3 %></span>
     </button>
     <% function sceneAfter(id) {
         const regex = /(B(?<book>[0-9]*)-)?Ch(?<chapter>[0-9]*)[a-c]-.*$/
@@ -133,41 +133,41 @@
     } %>
     <% if (sceneAfter(locals.v_current_scene)) { %>
         <button class="stat-field" id="bluff"
-        onclick="updateStat('bluff', 'v_bluff_aux', 'bluff', 'bluff_value')"
+        onclick="updateStat(this.id)"
         style="grid-column: 1 / span 2; grid-row: 9;">
             <%= statsBluffText %>:
             <span id="bluff_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_bluff) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
             <%= (locals.v_bluff) || 0 %>
             </span>
             /
-            <%= (locals.v_max_stat) || 3 %>
+            <span id="bluff_max"><%= (locals.v_max_stat) || 3 %></span>
         </button>
 
         <button class="stat-field" id="magical_sense"
-        onclick="updateStat('magical_sense', 'v_magical_sense_aux', 'magical_sense', 'magical_sense_value')"
+        onclick="updateStat(this.id)"
         style="grid-column: 1; grid-row: 10;">
             <%= statsMagicalSenseText %>:
             <span id="magical_sense_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_magical_sense) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
             <%= (locals.v_magical_sense) || 0 %>
             </span>
             /
-            <%= (locals.v_max_stat) || 3 %>
+            <span id="magical_sense_max"><%= (locals.v_max_stat) || 3 %></span>
         </button>
 
         <button class="stat-field" id="aura_hardening"
-        onclick="updateStat('aura_hardening', 'v_aura_hardening_aux', 'aura_hardening', 'aura_hardening_value')"
+        onclick="updateStat(this.id)"
         style="grid-column: 2; grid-row: 10;">
             <%= statsAuraHardeningText %>:
             <span id="aura_hardening_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_aura_hardening) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
             <%= (locals.v_aura_hardening) || 0 %>
             </span>
             /
-            <%= (locals.v_max_stat) || 3 %>
+            <span id="aura_hardening_max"><%= (locals.v_max_stat) || 3 %></span>
         </button>
     <% } %>
 </div>
 <div id="stats-button-container">
-<button onclick="stats_aux = getAuxiliaryStats();initializeStats(stats_aux);stats_changed = false;" 
+<button onclick="window.location.reload()" 
     id="cancel-changes"><%= statsCancelText %></button>
 <button onclick="confirmStats()" 
     id="confirm-changes"><%= statsConfirmText %></button>


### PR DESCRIPTION
Moves the storage of stats to the DOM for more simplicity, instead of using a "stats_aux" structure.