### PR TITLE
Properly show increase in magical stats

### DIFF
--- a/templates/stats.ejs
+++ b/templates/stats.ejs
@@ -2,11 +2,9 @@
     <% if (locals.v_b3_ch11_magic || 0) { %>
         <button class="stat-field magic-special" id="magical_power" onclick="void(0)" 
         style="grid-column: 1; grid-row: 1;">
-        <!-- This initial content is tied to the EJS variable only once.
-        Later, the content for each of the stat-field is tied to the auxiliary variables -->
             <%= statsMagicalPowerText %>:
             <span id="magical_power_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_magical_power) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
-                <%= (locals.v_magical_power) || 0 %>
+                <%= (locals.v_b3_ch11_magic) || 0 %>
             </span>
         </button>
 
@@ -14,7 +12,7 @@
         style="grid-column: 2; grid-row: 1;">
             <%= statsMagicalKnowledgeText %>:
             <span id="magical_knowledge_value" <% if (maximized) { %> _="on load wait 100ms then repeat while counter >= <%= (locals.v_magical_knowledge) || 0  %> set my.innerHTML to counter then wait 10ms end" <% } %>>
-                <%= (locals.v_magical_knowledge) || 0 %>
+                <%= (locals.v_b3_ch11_magic) || 0 %>
             </span>
         </button>
     <% } %>


### PR DESCRIPTION
Magical stats stayed at 0 because we assumed they worked similarly to regular stats, except they do not. They are tied to v_b3_ch11_magic, which is probably bad design and should be revisited at some point.